### PR TITLE
sam9x60ek fix wilc

### DIFF
--- a/sam9x60ek/sam9x60ek_wilc.dtso
+++ b/sam9x60ek/sam9x60ek_wilc.dtso
@@ -6,6 +6,14 @@
  * Copyright (C) 2019 Microchip Technology, Inc.
  * Author: Cristian Birsan <cristian.birsan@microchip.com>
  *
+ * NOTE: this device tree implements also the errata 5.3 recommendation
+ * to separate the reset line by cutting it and rewiring it from the
+ * J16 connector. Therefore pin PC31 is used as reset GPIO. If the errata
+ * modification is not implemented, this should be switched to PB25 in
+ * both occourences in this file.
+ *
+ * For more details see section 5.3 of:
+ * https://ww1.microchip.com/downloads/en/DeviceDoc/SAM9X60-EK-UG-DS50002907B.pdf
  */
 /dts-v1/;
 /plugin/;

--- a/sam9x60ek/sam9x60ek_wilc.dtso
+++ b/sam9x60ek/sam9x60ek_wilc.dtso
@@ -38,7 +38,7 @@
 		powerdown-gpios = <&pioA 29 GPIO_ACTIVE_HIGH>;
 		pinctrl-0 = <&pinctrl_wilc_pwrseq_default>;
 		pinctrl-names = "default";
-		status = "disabled";
+		status = "okay";
 	};
 };
 


### PR DESCRIPTION
This PR is composed by two changes to make the WILC overlay work correctly on SAM9x60-EK (rev B, if that changes things, but could not find rev A docs/schematics any place) with a soldered ATWILCx000 module.

It is composed of two commits for separate issues (therefore I would suggest to not squash them):
- enable the pwrseq in DTS, otherwise the module will never be triggered
- correct the reset PIN as per datasheet (see commit for references)

This has been tested with success with the SAM9x60-EK. Note the same mistakes are present also in the prebuilt images shipped on the website that therefore prevent the WILC module working.

Signed-off-by: Federico Pellegrin <fede@evolware.org>