### PR TITLE
sama7d65_curiosity: Fix reversed I2C0 GPIO pin configuration.

### DIFF
--- a/sama7d65_curiosity/sama7d65_curiosity_lvds.dtso
+++ b/sama7d65_curiosity/sama7d65_curiosity_lvds.dtso
@@ -74,8 +74,8 @@
 	pinctrl-names = "default", "gpio";
 	pinctrl-0 = <&pinctrl_i2c0_default>;
 	pinctrl-1 = <&pinctrl_i2c0_gpio>;
-	sda-gpios = <&pioa PIN_PC6 GPIO_ACTIVE_HIGH>;
-	scl-gpios = <&pioa PIN_PC7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+	sda-gpios = <&pioa PIN_PC7 GPIO_ACTIVE_HIGH>;
+	scl-gpios = <&pioa PIN_PC6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 	i2c-analog-filter;
 	i2c-digital-filter;
 	i2c-digital-filter-width-ns = <35>;

--- a/sama7d65_curiosity/sama7d65_curiosity_mipi.dtso
+++ b/sama7d65_curiosity/sama7d65_curiosity_mipi.dtso
@@ -101,8 +101,8 @@
 	pinctrl-names = "default", "gpio";
 	pinctrl-0 = <&pinctrl_i2c0_default>;
 	pinctrl-1 = <&pinctrl_i2c0_gpio>;
-	sda-gpios = <&pioa PIN_PC6 GPIO_ACTIVE_HIGH>;
-	scl-gpios = <&pioa PIN_PC7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+	sda-gpios = <&pioa PIN_PC7 GPIO_ACTIVE_HIGH>;
+	scl-gpios = <&pioa PIN_PC6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 	i2c-analog-filter;
 	i2c-digital-filter;
 	i2c-digital-filter-width-ns = <35>;


### PR DESCRIPTION
According to the SPEC, PIN_PC6 is defined as TWI clock and PIN_PC7 as TWI data.